### PR TITLE
Use snake_case in index names. APOC likes this better - no backticks …

### DIFF
--- a/src/main/kotlin/com/embabel/agent/rag/neo/drivine/CypherFilterConverter.kt
+++ b/src/main/kotlin/com/embabel/agent/rag/neo/drivine/CypherFilterConverter.kt
@@ -181,6 +181,36 @@ class CypherFilterConverter(
             "$nodeAlias.${filter.key} CONTAINS \$$paramName"
         }
 
+        is PropertyFilter.ContainsIgnoreCase -> {
+            val paramName = "$paramPrefix${counter.next()}"
+            params[paramName] = filter.value.lowercase()
+            "toLower($nodeAlias.${filter.key}) CONTAINS \$$paramName"
+        }
+
+        is PropertyFilter.EqIgnoreCase -> {
+            val paramName = "$paramPrefix${counter.next()}"
+            params[paramName] = filter.value.lowercase()
+            "toLower($nodeAlias.${filter.key}) = \$$paramName"
+        }
+
+        is PropertyFilter.StartsWith -> {
+            val paramName = "$paramPrefix${counter.next()}"
+            params[paramName] = filter.value
+            "$nodeAlias.${filter.key} STARTS WITH \$$paramName"
+        }
+
+        is PropertyFilter.EndsWith -> {
+            val paramName = "$paramPrefix${counter.next()}"
+            params[paramName] = filter.value
+            "$nodeAlias.${filter.key} ENDS WITH \$$paramName"
+        }
+
+        is PropertyFilter.Like -> {
+            val paramName = "$paramPrefix${counter.next()}"
+            params[paramName] = filter.pattern
+            "$nodeAlias.${filter.key} =~ \$$paramName"
+        }
+
         is PropertyFilter.And -> {
             val clauses = filter.filters.map { convertFilter(it, params, counter) }
             if (clauses.size == 1) {

--- a/src/main/kotlin/com/embabel/agent/rag/neo/drivine/NeoRagServiceProperties.kt
+++ b/src/main/kotlin/com/embabel/agent/rag/neo/drivine/NeoRagServiceProperties.kt
@@ -29,10 +29,10 @@ class NeoRagServiceProperties {
     var entityNodeName: String = NamedEntityData.ENTITY_LABEL
     var name: String = "DrivineRagService"
     var description: String = "Neo RAG service using Drivine for querying and embedding"
-    var contentElementIndex: String = "embabel-content-index"
-    var entityIndex: String = "embabel-entity-index"
-    var contentElementFullTextIndex: String = "embabel-content-fulltext-index"
-    var entityFullTextIndex: String = "embabel-entity-fulltext-index"
+    var contentElementIndex: String = "embabel_content_index"
+    var entityIndex: String = "embabel_entity_index"
+    var contentElementFullTextIndex: String = "embabel_content_fulltext_index"
+    var entityFullTextIndex: String = "embabel_entity_fulltext_index"
 
     override fun toString(): String {
         return "${javaClass.simpleName}(chunkNodeName='$chunkNodeName', entityNodeName='$entityNodeName', name='$name', description='$description', contentElementIndex='$contentElementIndex', entityIndex='$entityIndex', contentElementFullTextIndex='$contentElementFullTextIndex', entityFullTextIndex='$entityFullTextIndex')"

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -35,10 +35,10 @@ embabel:
         uri: ${NEO4J_URI:bolt://localhost:7687}
         username: ${NEO4J_USERNAME:neo4j}
         password: ${NEO4J_PASSWORD:brahmsian}
-        content-element-index: embabel-content-index
-        entity-index: embabel-entity-index
-        content-element-full-text-index: embabel-content-fulltext-index
-        entity-full-text-index: embabel-entity-fulltext-index
+        content-element-index: embabel_content_index
+        entity-index: embabel_entity_index
+        content-element-full-text-index: embabel_content_fulltext_index
+        entity-full-text-index: embabel_entity_fulltext_index
         chunk-node-name: Chunk
         entity-node-name: Entity
         max-chunk-size: 1500


### PR DESCRIPTION
# Changed default index names from hyphenated snake case

Changed default index names from hyphenated (`embabel-content-index`) to snake_case (`embabel_content_index`)

APOC procedures don't require backtick-escaping for snake_case index names, unlike hyphenated ones

## Files changed

 - `NeoRagServiceProperties.kt` — updated 4 default index name strings
 - `application.yml` (test) — already used snake_case; updated to stay consistent

# Add Missing Cases to CypherFilter

```
  ┌────────────────────┬───────────────────────────────────────────────────────┐                                                                      
  │       Filter       │                        Cypher                         │                                                                      
  ├────────────────────┼───────────────────────────────────────────────────────┤                                                                    
  │ StartsWith         │ e.key STARTS WITH $param                              │                                                                      
  ├────────────────────┼───────────────────────────────────────────────────────┤                                                                      
  │ EndsWith           │ e.key ENDS WITH $param                                │
  ├────────────────────┼───────────────────────────────────────────────────────┤
  │ ContainsIgnoreCase │ toLower(e.key) CONTAINS $param (value pre-lowercased) │
  ├────────────────────┼───────────────────────────────────────────────────────┤
  │ EqIgnoreCase       │ toLower(e.key) = $param (value pre-lowercased)        │
  ├────────────────────┼───────────────────────────────────────────────────────┤
  │ Like               │ e.key =~ $param (Cypher regex)                        │
  └────────────────────┴───────────────────────────────────────────────────────┘
```
