### PR TITLE
Implement chunk expansion

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,6 +27,8 @@ jobs:
         run: |
           mkdir -p /home/runner
           echo "testcontainers.reuse.enable=true" > /home/runner/.testcontainers.properties
+          # Docker 29+ raised minimum API version to 1.44; Testcontainers 1.x defaults to 1.32
+          echo "api.version=1.44" > ~/.docker-java.properties
       - name: Build and test
         run: mvn -U -B test verify
 
@@ -47,5 +49,7 @@ jobs:
           # Configure Testcontainers for Linux
           mkdir -p /home/runner
           echo "testcontainers.reuse.enable=true" > /home/runner/.testcontainers.properties
+          # Docker 29+ raised minimum API version to 1.44; Testcontainers 1.x defaults to 1.32
+          echo "api.version=1.44" > ~/.docker-java.properties
           # Build without Sonar Cloud
           mvn -U -B test verify

--- a/src/main/kotlin/com/embabel/agent/rag/neo/drivine/mappers/DefaultContentElementRowMapper.kt
+++ b/src/main/kotlin/com/embabel/agent/rag/neo/drivine/mappers/DefaultContentElementRowMapper.kt
@@ -17,6 +17,7 @@ package com.embabel.agent.rag.neo.drivine.mappers
 
 import com.embabel.agent.rag.model.Chunk
 import com.embabel.agent.rag.model.ContentElement
+import com.embabel.agent.rag.model.LeafSection
 import com.embabel.agent.rag.model.MaterializedDocument
 import org.drivine.mapper.RowMapper
 import java.time.Instant
@@ -51,6 +52,15 @@ internal class DefaultContentElementRowMapper : RowMapper<ContentElement> {
                 id = row["id"] as String,
                 text = row["text"] as String,
                 parentId = row["parentId"] as String,
+                metadata = metadata,
+            )
+        if (labels.contains("LeafSection"))
+            return LeafSection(
+                id = row["id"] as String,
+                title = allProperties["title"] as? String ?: "",
+                text = row["text"] as? String ?: "",
+                parentId = row["parentId"] as? String,
+                uri = row["uri"] as? String,
                 metadata = metadata,
             )
         if (labels.contains("Document") || labels.contains("ContentRoot")) {

--- a/src/main/resources/cypher/expand_by_sequence.cypher
+++ b/src/main/resources/cypher/expand_by_sequence.cypher
@@ -1,0 +1,14 @@
+MATCH (c:ContentElement:Chunk)
+WHERE c.container_section_id = $containerSectionId
+  AND c.sequence_number >= $minSeq
+  AND c.sequence_number <= $maxSeq
+RETURN {
+  id: c.id,
+  uri: c.uri,
+  text: c.text,
+  parentId: c.parentId,
+  ingestionDate: c.ingestionTimestamp,
+  labels: labels(c),
+  properties: properties(c)
+} AS result
+ORDER BY c.sequence_number

--- a/src/main/resources/cypher/expand_zoom_out.cypher
+++ b/src/main/resources/cypher/expand_zoom_out.cypher
@@ -1,0 +1,12 @@
+MATCH (child:ContentElement {id: $id})
+WHERE child.parentId IS NOT NULL
+MATCH (parent:ContentElement {id: child.parentId})
+RETURN {
+  id: parent.id,
+  uri: parent.uri,
+  text: parent.text,
+  parentId: parent.parentId,
+  ingestionDate: parent.ingestionTimestamp,
+  labels: labels(parent),
+  properties: properties(parent)
+} AS result


### PR DESCRIPTION
 DrivineStore.expandResult() is implemented — the broadenChunk and zoomOut RAG tools now work against Neo4j instead of throwing NotImplementedError.                                                                                                                                
                                                                                                                                                      
##  What changed

- DrivineStore.kt — Replaced TODO("Not yet implemented") with two methods:
- expandBySequence() — queries chunks in the same container_section_id within a sequence_number window
- expandByZoomOut() — single Cypher hop from child to parent via parentId
- DefaultContentElementRowMapper.kt — Added LeafSection mapping so ZOOM_OUT can deserialize parent section nodes
- expand_by_sequence.cypher / expand_zoom_out.cypher — Externalized queries following existing .cypher file convention
- DrivineStoreTest.kt — Replaced 2 bug-repro assertThrows<NotImplementedError> tests with 6 tests: sequence expansion, missing metadata fallback,
  non-existent chunk, cross-section isolation, zoom-out to parent, and zoom-out with missing parent

