### PR TITLE
Add repository_dispatch event for agent snapshots

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,8 @@
 # documentation.
 name: Build
 on:
+   repository_dispatch:
+    types: [agent-snapshots-deployed]
   push:
   pull_request:
     types: [ opened, synchronize, reopened ]


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The workflow is now also triggered by a `repository_dispatch` event with the type `agent-snapshots-deployed`, in addition to the existing triggers.