### PR TITLE
fix: open DrivineStore and DrivineCypherSearch for Spring proxying

### DIFF
--- a/src/main/kotlin/com/embabel/agent/rag/neo/drivine/DrivineCypherSearch.kt
+++ b/src/main/kotlin/com/embabel/agent/rag/neo/drivine/DrivineCypherSearch.kt
@@ -34,7 +34,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.transaction.annotation.Transactional
 
-class DrivineCypherSearch @JvmOverloads constructor(
+open class DrivineCypherSearch @JvmOverloads constructor(
     private val persistenceManager: PersistenceManager,
     private val queryResolver: LogicalQueryResolver = FixedLocationLogicalQueryResolver(),
     private val namedEntityDataMapper: RowMapper<NamedEntityData> = NamedEntityDataRowMapper(),

--- a/src/main/kotlin/com/embabel/agent/rag/neo/drivine/DrivineStore.kt
+++ b/src/main/kotlin/com/embabel/agent/rag/neo/drivine/DrivineStore.kt
@@ -57,7 +57,7 @@ import org.springframework.transaction.PlatformTransactionManager
 import org.springframework.transaction.TransactionDefinition
 import org.springframework.transaction.support.TransactionTemplate
 
-class DrivineStore @JvmOverloads constructor(
+open class DrivineStore @JvmOverloads constructor(
     val persistenceManager: PersistenceManager,
     val properties: NeoRagServiceProperties,
     chunkerConfig: ContentChunker.Config,


### PR DESCRIPTION
  ### Hello team 
First off — I've been using the Embabel agent framework for about a year and a half now, and 
  I genuinely think it's one of the best things happening in the AI engineering space right   
  now. Building on top of it has been an absolute pleasure, and the way it bridges agent       
  orchestration with the JVM ecosystem is something nobody else is doing this well. That's my
  honest take after having tried most of the alternatives out there.  
  
   I've been building a production agentic SaaS platform on top of it and it's been a solid foundation for our agentic 
  RAG pipeline over Neo4j.                                                                    
                                                                                 
  I ran into a blocker while integrating _embabel-agent-rag-neo-drivine 0.1.2_ with _Embabel Agent 0.3.5_
  into a _Spring Boot 3.2.7_ application running on _JDK 21_ with _Kotlin 2.1.0_ and _Drivine 0.0.14._ 
                                                                                
  Basically, Spring tries to create CGLIB proxies around DrivineStore and DrivineCypherSearch
  for @Transactional support, but both are Kotlin classes — and in Kotlin, all classes are     
  final by default unless explicitly marked open. Spring's AOP infrastructure needs to generate
   a subclass at runtime to intercept transactional method calls, and CGLIB cannot extend a    
  final class. This is a well-known Kotlin-Spring friction point — it's the exact reason the 
  kotlin-spring compiler plugin exists. Without either the plugin or the open keyword, any
  Kotlin class that participates in Spring's proxy-based AOP (transactions, caching, async,
  etc.) will fail at context initialization. Spring blows up at startup with:                  
                                                                                             
```
  AopConfigException: Could not generate CGLIB subclass of class                             
  com.embabel.agent.rag.neo.drivine.DrivineStore:
  Common causes of this problem include using a final class or a non-visible class                    
```                                                         
                                                       
  The ecosystem of the app has both JPA (Postgres multi-tenant) and _Drivine_ (Neo4j graph). Because              
  `DrivineConfiguration.drivineTransactionManager() `is `@ConditionalOnMissingBean`, it never gets
  created — JPA already registered a `PlatformTransactionManager`. So I  had to create a custom   
  _Drivine_ transaction manager bean and wire it through these classes. That's when CGLIB kicks
  in and hits the final class wall.

  This is pretty much guaranteed to bite anyone combining Drivine with JPA, Hibernate, or any  
  other Spring-managed datasource — which is the majority of real-world JVM applications. Most
  production setups won't be running Neo4j alone; they'll have a relational DB alongside it for
   user data, sessions, billing, etc. Cross-datasource usage is the norm in the JVM ecosystem,
  not the exception.

  Just added open to both class declarations. Minimal change, no behavior difference, works    
  regardless of the consumer's build toolchain (no allopen plugin 
  
And if you're using Drivine alongside JPA, you'll also need to explicitly create your own Drivine
   transaction manager since the autoconfigured one gets skipped:
                                                                                               
```
  @Bean("drivineTransactionManager")                                                         
  public PlatformTransactionManager drivineTransactionManager(TransactionContextHolder ctx) {
      return new DrivineTransactionManager(ctx);
  }
```

  Thanks for the great work on this project — looking forward to future releases.    
   
   
   _P.S. — One thing we'd love to see down the road is some form of multi-tenancy support in the 
  RAG layer. In our case we're doing property-based tenant isolation (tenantId on every Neo4j  
  node, injected into every Cypher query), but it would be amazing if Drivine or the RAG       
  pipeline had first-class awareness of tenant context — even something lightweight like a
  tenant-scoped query filter or a hook to inject tenant constraints before queries execute. As 
  more teams adopt this for production SaaS, tenant isolation becomes table stakes. Just a   
  thought for the roadmap._   